### PR TITLE
Add sign in, sign up and log out links_to

### DIFF
--- a/app/views/navbar/_navbar.html.erb
+++ b/app/views/navbar/_navbar.html.erb
@@ -1,7 +1,8 @@
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
   <div class="container-fluid">
     <%= link_to "Let´s Learn", home_path, class: "navbar-brand"%>
-    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent"
+      aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>
     <div class="collapse navbar-collapse" id="navbarSupportedContent">
@@ -11,9 +12,9 @@
           <a class="nav-link active" aria-current="page" href="#">Home</a>
         </li>
 
-
         <li class="nav-item dropdown">
-          <a class="nav-link dropdown-toggle active" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+          <a class="nav-link dropdown-toggle active" id="navbarDropdown" role="button" data-bs-toggle="dropdown"
+            aria-expanded="false">
             Subjects
           </a>
           <ul role="menu" class="dropdown-menu" aria-labelledby="navbarDropdown">
@@ -23,6 +24,23 @@
             <li><%= link_to "English", teachers_path(:summary => "English"), class: "dropdown-item" %></li>
           </ul>
         </li>
+
+        <% if student_signed_in? %>
+          <li class="nav-item">
+            <%= link_to 'Log out', destroy_student_session_path, method: :delete, class: "nav-link active", id: "logOutS" %>
+          </li>
+        <% elsif teacher_signed_in? %>
+          <li class="nav-item">
+            <%= link_to 'Log out', destroy_teacher_session_path, method: :delete, class: "nav-link active", id: "logOutT" %>
+          </li>
+        <% else %>
+          <li class="nav-item">
+            <%= link_to 'Sign in', home_path, class: "nav-link active", id: "signIn" %>
+          </li>
+          <li class="nav-item">
+            <%= link_to 'Sign up', register_path, class: "nav-link active", id: "signUp" %>
+          </li>
+        <% end %>
 
       </ul>
     </div>


### PR DESCRIPTION
Was added links_to of sign in, sign up and log out in the navbar, with the functionality of show
each link denpending if a user is signed in or logged out

# Description
What did you implemented/Why did you implemented this:
 - Have added links_to in the navbar for sign in, sign up and log out
 - Have added the functionality of showing each link_to depending if a user is signed in or logged out
 
 Example:
  - I've added coverage for testing all new methods. I used Faker for a few random user emails and names.
  
  ## Screenshots 
![Screenshot from 2021-08-31 16-06-37](https://user-images.githubusercontent.com/57637591/131746162-fe6b7276-ba0b-4b0d-9705-4c48212632ad.png)
![Screenshot from 2021-08-31 16-07-08](https://user-images.githubusercontent.com/57637591/131746165-c502ec2a-c46f-4809-87e1-e5557a6f921a.png)
![Screenshot from 2021-08-31 16-07-18](https://user-images.githubusercontent.com/57637591/131746167-601f2886-1b86-463c-b6d3-34f141606e42.png)

